### PR TITLE
Update popup menu style for GNOME 43/44

### DIFF
--- a/panel.js
+++ b/panel.js
@@ -104,7 +104,7 @@ var InputPanel = GObject.registerClass(class InputPanel extends GObject.Object {
         if (len > labelLen) {
             for (let i = 0; i < len - labelLen; i++) {
                 let item = createLabel({
-                    style_class : 'candidate-box kimpanel-label',
+                    style_class : 'popup-menu-item kimpanel-label',
                     style : this.text_style,
                     text : '',
                     reactive : true
@@ -156,10 +156,10 @@ var InputPanel = GObject.registerClass(class InputPanel extends GObject.Object {
         for (var i = 0; i < labelLen; i++) {
             if (i == cursor)
                 this.lookupTableLayout.get_children()[i].add_style_pseudo_class(
-                    'selected');
+                    'active');
             else
                 this.lookupTableLayout.get_children()[i]
-                    .remove_style_pseudo_class('selected');
+                    .remove_style_pseudo_class('active');
         }
     }
     setVertical(vertical) { this.lookupTableLayout.set_vertical(vertical); }

--- a/panel.js
+++ b/panel.js
@@ -104,11 +104,12 @@ var InputPanel = GObject.registerClass(class InputPanel extends GObject.Object {
         if (len > labelLen) {
             for (let i = 0; i < len - labelLen; i++) {
                 let item = createLabel({
-                    style_class : 'kimpanel-candidate-item kimpanel-label',
+                    style_class : 'candidate-box kimpanel-label',
                     style : this.text_style,
                     text : '',
                     reactive : true
                 });
+                item.add_style_class_name('kimpanel-candidate-item');
                 item.candidate_index = 0;
                 item.ignore_focus = true;
                 item._buttonReleaseId =
@@ -155,10 +156,10 @@ var InputPanel = GObject.registerClass(class InputPanel extends GObject.Object {
         for (var i = 0; i < labelLen; i++) {
             if (i == cursor)
                 this.lookupTableLayout.get_children()[i].add_style_pseudo_class(
-                    'active');
+                    'selected');
             else
                 this.lookupTableLayout.get_children()[i]
-                    .remove_style_pseudo_class('active');
+                    .remove_style_pseudo_class('selected');
         }
     }
     setVertical(vertical) { this.lookupTableLayout.set_vertical(vertical); }

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -4,7 +4,7 @@
 
 .popup-menu-content.kimpanel-popup-content {
   /* you may customize pointer box here */
-  padding: 6px;
+  /* padding: 6px; */
 }
 
 .kimpanel-label {
@@ -18,18 +18,18 @@
 }
 
 .kimpanel-candidate-item:hover {
-  border-radius: 14px;
-  background-color: rgba(200,200,200,0.33);
+  /* border-radius: 14px; */
+  /* background-color: rgba(200,200,200,0.33); */
 }
 
-.kimpanel-candidate-item:active {
-  border-radius: 14px;
-  background-color: rgba(200,200,200,0.33);
+.kimpanel-candidate-item:selected {
+  /* border-radius: 14px; */
+  /* background-color: rgba(200,200,200,0.33); */
 }
 
-.kimpanel-candidate-item:active:hover {
-  border-radius: 14px;
-  background-color: rgba(200,200,200,0.15);
+.kimpanel-candidate-item:selected:hover {
+  /* border-radius: 14px; */
+  /* background-color: rgba(200,200,200,0.15); */
 }
 
 .minwidth-zero {

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -4,13 +4,13 @@
 
 .popup-menu-content.kimpanel-popup-content {
   /* you may customize pointer box here */
-  padding: 0.4em;
+  padding: 6px;
 }
 
 .kimpanel-label {
   font-family:sans;
   font-weight:normal;
-  padding: 0.3em;
+  padding: 0.4em;
 }
 
 .kimpanel-candidate-item {
@@ -18,17 +18,17 @@
 }
 
 .kimpanel-candidate-item:hover {
-  border-radius: 4px;
+  border-radius: 14px;
   background-color: rgba(200,200,200,0.33);
 }
 
 .kimpanel-candidate-item:active {
-  border-radius: 4px;
+  border-radius: 14px;
   background-color: rgba(200,200,200,0.33);
 }
 
 .kimpanel-candidate-item:active:hover {
-  border-radius: 4px;
+  border-radius: 14px;
   background-color: rgba(200,200,200,0.15);
 }
 

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -15,6 +15,7 @@
 
 .kimpanel-candidate-item {
   cursor: pointer;
+  transition-duration: 0ms;
 }
 
 .kimpanel-candidate-item:hover {
@@ -22,12 +23,12 @@
   /* background-color: rgba(200,200,200,0.33); */
 }
 
-.kimpanel-candidate-item:selected {
+.kimpanel-candidate-item:active {
   /* border-radius: 14px; */
   /* background-color: rgba(200,200,200,0.33); */
 }
 
-.kimpanel-candidate-item:selected:hover {
+.kimpanel-candidate-item:active:hover {
   /* border-radius: 14px; */
   /* background-color: rgba(200,200,200,0.15); */
 }


### PR DESCRIPTION
The popup menu has a corner radius of 20px in GNOME 43/44. In the current style the candidate-item box is too sharp and looks a bit awkward. Set the radius of the candidate-item box to 14px, the padding of the popup to 6px (summing up to 20px), and increase the space a little between text and the box, so that the popup menu fits in better now and looks more similar to e.g. the context menu.

Screenshots

Before:
![kimpanel_before](https://user-images.githubusercontent.com/2097707/225231970-0519e008-a9ac-4b24-a899-1c07748884aa.png)

After:
![kimpanel_after](https://user-images.githubusercontent.com/2097707/225231983-2a14cef3-f833-4bc5-8224-08ca4072ca66.png)
