### PR TITLE
indicator & menu: set menu alignment to 0.5 (center)

### DIFF
--- a/indicator.js
+++ b/indicator.js
@@ -11,7 +11,7 @@ const Lib = Me.imports.lib;
 var KimIndicator = GObject.registerClass(
     class Indicator_KimIndicator extends PanelMenu.Button {
         _init(params) {
-            super._init(0.0, 'kimpanel');
+            super._init(0.5, 'kimpanel');
             params = Params.parse(params, {kimpanel : null});
             this._properties = {};
             this._propertySwitch = {};

--- a/menu.js
+++ b/menu.js
@@ -10,7 +10,7 @@ var KimMenu = class extends PopupMenu.PopupMenu {
     constructor(params) {
         params = Params.parse(params, {
             sourceActor : null,
-            arrowAlignment : 0.0,
+            arrowAlignment : 0.5,
             arrowSide : St.Side.TOP,
             kimpanel : null
         });


### PR DESCRIPTION
By default the indicator menu `menuAlignment` is set to `0.0`, which seems means "right aligned" (I cannot find accurate reference documentations but some posts ([1](https://www.reddit.com/r/gnome/comments/ywosx5/popup_menu_position_off/), [2](https://github.com/julio641742/gnome-shell-extension-reference/blob/master/tutorials/POPUPMENU-EXTENSION.md)) say so). It's a bit weird:

![Screenshot from 2023-04-02 03-40-39](https://user-images.githubusercontent.com/2109893/229311245-1c2be32a-130e-40c4-b094-379d32419ef9.png)

I modified this value locally to `0.5` (center aligned) and it looks better now:

![Screenshot from 2023-04-02 03-42-32](https://user-images.githubusercontent.com/2109893/229311295-5046c540-9c24-475c-a08f-755af4fc3356.png)

(My environment is GNOME 43, with appindicator extension on)
