### PR TITLE
Update CMake min version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.10)
 
 project(kimpanel-for-gnome-shell NONE)
 


### PR DESCRIPTION
## Description

Update the `cmake_minimum_required` version to fix the install error on CMake 4.0.

![Screenshot From 2025-04-08 18-31-05](https://github.com/user-attachments/assets/5ab40e5a-0899-4bb4-a3e3-eb43f8790818)
 